### PR TITLE
Add OpenAI API client and enrich project docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# AGENTS
+
+This repository hosts small utilities for making two language models talk to
+each other. When modifying code here:
+
+- Prefer clear docstrings and type hints for all functions.
+- Run `python -m py_compile` on the modified Python files before committing.
+- Keep line lengths to 100 characters or fewer.
+
+These guidelines apply to all files in this repository.
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,43 @@
 # LLM-duet
-Let 2 LLMs start an conversation with each other
+
+Utilities for letting two language models carry on a conversation with each
+other. The initial topic is provided by a human and the models take turns
+producing responses.
+
+## Features
+
+- `conversation.py` orchestrates a back-and-forth between two models.
+- Supports local [OLLAMA](https://ollama.ai) servers via `OllamaClient`.
+- Includes an `OpenAIClient` for running the duet through the OpenAI API.
+
+## Usage
+
+### Command line (OLLAMA)
+
+With an OLLAMA server running locally you can start a conversation directly
+from the command line:
+
+```bash
+python conversation.py "Discuss the future of robotics" --model-a llama2 --model-b mistral --turns 4
+```
+
+### From Python using the OpenAI API
+
+```python
+from conversation import have_conversation
+from openai_client import OpenAIClient
+
+client = OpenAIClient()  # uses the OPENAI_API_KEY environment variable
+history = have_conversation("gpt-3.5-turbo", "gpt-4", "Debate the future of AI", client=client)
+for model, text in history:
+    print(f"{model}: {text}")
+```
+
+## Development
+
+The repository contains only a few Python files. See `AGENTS.md` for coding
+guidelines.
+
+## License
+
+Distributed under the terms of the MIT license. See `LICENSE` for details.

--- a/conversation.py
+++ b/conversation.py
@@ -1,9 +1,22 @@
-"""Utilities to allow two local OLLAMA models to converse with each other."""
+"""Utilities to orchestrate a back-and-forth between two language models.
+
+The default implementation uses a local OLLAMA server, but any client object
+providing a ``generate`` method can be supplied, enabling use of remote APIs
+such as OpenAI's chat completions.
+"""
 from __future__ import annotations
 
-from typing import List, Tuple
+from typing import List, Tuple, Protocol, runtime_checkable
 
 from ollama_client import OllamaClient
+
+
+@runtime_checkable
+class LLMClient(Protocol):
+    """Protocol describing the methods a language model client must provide."""
+
+    def generate(self, model: str, prompt: str, stream: bool = False, **kwargs: object) -> str:
+        """Return a completion for ``prompt`` from ``model``."""
 
 
 def have_conversation(
@@ -11,7 +24,7 @@ def have_conversation(
     model_b: str,
     prompt: str,
     turns: int = 4,
-    client: OllamaClient | None = None,
+    client: LLMClient | None = None,
 ) -> List[Tuple[str, str]]:
     """Have two models converse by generating responses alternately.
 
@@ -26,8 +39,8 @@ def have_conversation(
         model response. Thus, ``turns`` of 4 will produce two responses from each
         model.
     client:
-        Optional :class:`OllamaClient` instance. If omitted a new client will be
-        created.
+        Optional client implementing :class:`LLMClient`. If omitted a new
+        :class:`OllamaClient` will be created.
 
     Returns
     -------

--- a/openai_client.py
+++ b/openai_client.py
@@ -1,0 +1,39 @@
+"""Client utilities for interacting with the OpenAI API."""
+from __future__ import annotations
+
+from typing import Optional
+
+try:  # pragma: no cover - import is trivial
+    from openai import OpenAI  # type: ignore
+except Exception:  # pragma: no cover - handled in generate
+    OpenAI = None  # type: ignore
+
+
+class OpenAIClient:
+    """Minimal wrapper around the OpenAI chat completions API.
+
+    Parameters
+    ----------
+    api_key:
+        API key used for authentication. If omitted, the ``OPENAI_API_KEY``
+        environment variable is used.
+    base_url:
+        Optional alternative base URL for the API.
+    """
+
+    def __init__(self, api_key: Optional[str] = None, base_url: Optional[str] = None) -> None:
+        if OpenAI is None:  # pragma: no cover - network library missing
+            raise ImportError("The 'openai' package is required to call the OpenAI API")
+        self._client = OpenAI(api_key=api_key, base_url=base_url)
+
+    def generate(self, model: str, prompt: str, stream: bool = False, **_: object) -> str:
+        """Generate a completion from the OpenAI API."""
+
+        if stream:  # pragma: no cover - streaming not implemented
+            raise NotImplementedError("Streaming responses are not supported")
+        response = self._client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return response.choices[0].message.content or ""
+


### PR DESCRIPTION
## Summary
- Allow conversations with any client implementing a `generate` method
- Provide an `OpenAIClient` for using OpenAI's chat completions API
- Expand README and add AGENTS instructions for contributors

## Testing
- `python -m py_compile conversation.py ollama_client.py openai_client.py`


------
https://chatgpt.com/codex/tasks/task_e_689a0ccdd9c88322b1bacfed55175785