### PR TITLE
Honor OLLAMA_HOST for server URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ separate installation.
 ### Command line (OLLAMA)
 
 With an OLLAMA server running locally you can start a conversation directly
-from the command line:
+from the command line. The client reads the ``OLLAMA_HOST`` environment
+variable to locate the server; it defaults to ``http://localhost:11434``:
 
 ```bash
 python conversation.py "Discuss the future of robotics" --model-a llama2 --model-b mistral --turns 4
@@ -35,8 +36,8 @@ python conversation.py "Discuss the future of robotics" --model-a llama2 --model
 
 ### From Python using an OLLAMA server
 
-`OllamaClient` connects to any running OLLAMA instance. Set `base_url` when the server is on
-another machine or on Windows:
+`OllamaClient` connects to any running OLLAMA instance. Set `base_url` or
+``OLLAMA_HOST`` when the server is on another machine or on Windows:
 
 ```python
 from conversation import have_conversation

--- a/ollama_client.py
+++ b/ollama_client.py
@@ -1,6 +1,7 @@
 """Client utilities for interacting with a local OLLAMA server."""
 from __future__ import annotations
 
+import os
 from typing import List, Dict, Optional
 
 try:  # pragma: no cover - import is trivial
@@ -15,11 +16,14 @@ class OllamaClient:
     Parameters
     ----------
     base_url:
-        URL where the OLLAMA server is accessible. Defaults to the standard
-        local installation URL.
+        URL where the OLLAMA server is accessible. If omitted the constructor
+        reads the ``OLLAMA_HOST`` environment variable and falls back to
+        ``"http://localhost:11434"`` when the variable is not set.
     """
 
-    def __init__(self, base_url: str = "http://localhost:11434") -> None:
+    def __init__(self, base_url: str | None = None) -> None:
+        if base_url is None:
+            base_url = os.environ.get("OLLAMA_HOST", "http://localhost:11434")
         self.base_url = base_url.rstrip("/")
 
     def generate(


### PR DESCRIPTION
## Summary
- Read `OLLAMA_HOST` env var in `OllamaClient` and fall back to `http://localhost:11434`
- Document environment variable usage and default host in README

## Testing
- `python -m py_compile ollama_client.py`


------
https://chatgpt.com/codex/tasks/task_e_689a3c674e80832294fed8bd6e87b4f5