### PR TITLE
Use explicit LLM client cast

### DIFF
--- a/conversation.py
+++ b/conversation.py
@@ -6,7 +6,7 @@ such as OpenAI's chat completions.
 """
 from __future__ import annotations
 
-from typing import List, Tuple, Protocol, runtime_checkable
+from typing import List, Tuple, Protocol, runtime_checkable, cast
 
 from ollama_client import OllamaClient
 
@@ -49,8 +49,7 @@ def have_conversation(
         produced.
     """
 
-    if client is None:
-        client = OllamaClient()
+    client = cast(LLMClient, client or OllamaClient())
 
     history: List[Tuple[str, str]] = []
     conversation_context = prompt


### PR DESCRIPTION
## Summary
- ensure `client` parameter always resolves to an `LLMClient` using `cast`

## Testing
- `python -m py_compile conversation.py`


------
https://chatgpt.com/codex/tasks/task_e_689a555e4e3483229f6df7eaa002a06d